### PR TITLE
Allow multiple 'external' definitions

### DIFF
--- a/dante/map.jinja
+++ b/dante/map.jinja
@@ -3,7 +3,7 @@
         'server': {
           'pkg': 'dante-server',
           'service': 'danted',
-          'config': '/etc/danted.conf',
+          'config': '/etc/danted.conf'
         }
     },
 }, merge=salt['pillar.get']('dante:lookup')) %}

--- a/dante/server/files/server.jinja
+++ b/dante/server/files/server.jinja
@@ -8,7 +8,16 @@ logoutput: {{ config.logoutput }}
 internal: {{ config.internal }}
 {%- endif %}
 {%- if config.external is defined %}
+{%-   if config.external is string %}
 external: {{ config.external }}
+{%-   else %}
+{%-     for ext in config.external %}
+external: {{ ext }}
+{%-     endfor %}
+{%-     if config.external_rotation is defined %}
+external.rotation: {{ config.external_rotation }}
+{%-     endif %}
+{%-   endif %}
 {%- endif %}
 
 {%- if config.socksmethod is defined %}

--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,15 @@ dante:
     logoutput: syslog /var/log/danted
     internal: eth0 port = 1080
     external: eth0
+# You can use multiple "external" keys:
+#   external:
+#     - eth0
+#     - eth1
+#     - 127.0.0.1
+# If you do, you'll probably need to define "external.rotation"; by default is
+# "none", which may not be what you want. See danted.conf(5) for more
+# information.
+#   external_rotation: route 
     socksmethod: none
     clientmethod: none
     user_privileged: proxy


### PR DESCRIPTION
This change will allow to define multiple "external" keys in the configuration file. This can be used when there are multiple available routes to the destination host.
